### PR TITLE
Closes #4

### DIFF
--- a/Sources/Anchor/Anchor+Constraints.swift
+++ b/Sources/Anchor/Anchor+Constraints.swift
@@ -57,11 +57,11 @@ fileprivate extension Anchor {
         let constraint = NSLayoutConstraint(
           item: item,
           attribute: $0.attribute,
-          relatedBy: relationValue,
+          relatedBy: relationValue ?? .equal,
           toItem: nil,
           attribute: .notAnAttribute,
-          multiplier: multiplierValue,
-          constant: $0.constant
+          multiplier: multiplierValue ?? 1,
+          constant: $0.constant ?? 0
         )
 
         return constraint
@@ -76,11 +76,11 @@ fileprivate extension Anchor {
       let constraint = NSLayoutConstraint(
         item: item,
         attribute: pin.attribute,
-        relatedBy: relationValue,
+        relatedBy: relationValue ?? .equal,
         toItem: anotherAnchor.item,
         attribute: anotherPin.attribute,
-        multiplier: multiplierValue,
-        constant: pin.constant
+        multiplier: multiplierValue ?? 1,
+        constant: pin.constant ?? 0
       )
 
       return constraint

--- a/Sources/Anchor/Anchor+Find.swift
+++ b/Sources/Anchor/Anchor+Find.swift
@@ -31,3 +31,79 @@ public extension Anchor {
     }).first
   }
 }
+
+extension NSLayoutConstraint {
+    func isEqual(to anchor: Anchor,_ firstItem: View? = nil) -> Bool {
+        if let firstItem = firstItem {
+            guard self.firstItem as? NSObject == firstItem else {
+                return false
+            }
+
+            guard self.secondItem as? NSObject == anchor.item as? View else {
+                return false
+            }
+        } else {
+            guard self.firstItem as? NSObject == anchor.item as? View else {
+                return false
+            }
+        }
+
+        if let identifier = anchor.identifierValue, identifier != self.identifier {
+            return false
+        }
+
+        guard anchor.pins.contains(where: {
+            return $0.attribute == self.firstAttribute && {
+                if let constant = $0.constant {
+                    return constant == self.constant
+                }
+
+                return true
+            }($0)
+        }) else {
+            return false
+        }
+
+        if let relationValue = anchor.relationValue, relationValue != self.relation {
+            return false
+        }
+
+        if let priorityValue = anchor.priorityValue, priorityValue != self.priority.rawValue {
+            return false
+        }
+
+        if let multiplierValue = anchor.multiplierValue, multiplierValue != self.multiplier {
+            return false
+        }
+
+        return true
+    }
+}
+
+public extension Anchor {
+    func findByContent() -> [NSLayoutConstraint] {
+        guard let view = item as? View else {
+            return []
+        }
+
+        let constraints: [NSLayoutConstraint] = {
+            if case .anchor(let relatedTo) = self.toValue {
+                return (relatedTo.item as? View)?.constraints.filter {
+                    $0.isEqual(to: relatedTo, view)
+                }
+            }
+
+            var constraints: [NSLayoutConstraint] = view.superview?.constraints ?? []
+            if self.pins.contains(where: { $0.attribute == .width || $0.attribute == .height }) {
+                constraints.append(contentsOf: view.constraints)
+            }
+
+            return constraints
+
+        }() ?? []
+
+        return constraints.filter { constraint in
+            constraint.isEqual(to: self)
+        } ?? []
+    }
+}

--- a/Sources/Anchor/Anchor.swift
+++ b/Sources/Anchor/Anchor.swift
@@ -13,9 +13,9 @@ public class Anchor: ConstraintProducer {
 
   class Pin {
     let attribute: Attribute
-    var constant: CGFloat
+    var constant: CGFloat?
 
-    init(_ attribute:  Attribute, constant: CGFloat = 0) {
+    init(_ attribute:  Attribute, constant: CGFloat? = nil) {
       self.attribute = attribute
       self.constant = constant
     }
@@ -27,11 +27,11 @@ public class Anchor: ConstraintProducer {
   // value: constant
   var pins: [Pin] = []
 
-  var multiplierValue: CGFloat = 1
+  var multiplierValue: CGFloat?
   var priorityValue: Float?
   var identifierValue: String?
   var referenceBlock: (([NSLayoutConstraint]) -> Void)?
-  var relationValue: Relation = .equal
+  var relationValue: Relation? = nil
   var toValue: To = .none
 
   /// Init with View


### PR DESCRIPTION
So I change the find method to search for all constraints that fit on anchor attributes. The quantity of parameters matters so the find method can find the specific constraint that you want to find. Because constraints are infinity and it is so difficult to find only one, so now find method returns an array of constraints. I tested a lot on my project because I can create and update the same constraint in the same method so I really need this working.

My idea is if there is an array of constraints that can be equal to anchor attributes `view.anchor.top.find()`, I will not call the 'activate(...)' method and I will only update the NSLayoutConstraint properties.